### PR TITLE
Prevent text selection during drag

### DIFF
--- a/src/InputRange/InputRange.js
+++ b/src/InputRange/InputRange.js
@@ -416,6 +416,8 @@ export default class InputRange extends React.Component {
       return;
     }
 
+    event.preventDefault();
+
     const key = getKeyByPosition(this, position);
 
     this.updatePosition(key, position);

--- a/test/InputRange.spec.js
+++ b/test/InputRange.spec.js
@@ -279,7 +279,21 @@ describe('InputRange', () => {
       event = {
         clientX: 100,
         clientY: 200,
+        preventDefault: jasmine.createSpy('preventDefault'),
       };
+    });
+
+    it('should call event.preventDefault if not disabled', () => {
+      inputRange.handleTrackMouseDown(event, track, position);
+
+      expect(event.preventDefault).toHaveBeenCalledWith();
+    });
+
+    it('should not call event.preventDefault if disabled', () => {
+      inputRange = renderComponent(<InputRange disabled={true} defaultValue={10} onChange={onChange}/>);
+      inputRange.handleTrackMouseDown(event, track, position);
+
+      expect(event.preventDefault).not.toHaveBeenCalledWith();
     });
 
     it('should not set a new position if disabled', () => {


### PR DESCRIPTION
Fails in Firefox on Mac at least, Safari and Chrome are fine.

Steps to reproduce:
1. Open the demo at http://codepen.io/davidchin/full/GpNvqw/ in Firefox
2. Click and hold one of the handles in the top slider in order to initiate a drag
3. While still holding down the mousebutton, drag straight up

Result:
The number above the handle gets selected.

I just use `event.preventDefault()` to prevent text selection during the mouse move event.