### PR TITLE
Fix handleInteractionStart when only defaultValue is provided

### DIFF
--- a/src/InputRange/InputRange.js
+++ b/src/InputRange/InputRange.js
@@ -459,7 +459,7 @@ export default class InputRange extends React.Component {
       return;
     }
 
-    _this.startValue = this.props.value;
+    _this.startValue = this.props.value || this.props.defaultValue;
   }
 
   /**

--- a/test/InputRange.spec.js
+++ b/test/InputRange.spec.js
@@ -486,6 +486,23 @@ describe('InputRange', () => {
       expect(onChangeComplete).toHaveBeenCalledWith(inputRange, value);
     });
 
+    it('should call onChangeComplete if value has changed since the start of interaction when only defaultValue was provided', () => {
+      const defaultValue = value;
+      inputRange = renderComponent(
+        <InputRange maxValue={20} minValue={0} defaultValue={defaultValue} onChange={onChange} onChangeComplete={onChangeComplete}/>
+      );
+      slider = ReactDOM.findDOMNode(inputRange.refs.sliderMax);
+
+      slider.dispatchEvent(mouseDownEvent);
+      value += 2;
+      inputRange = rerenderComponent(
+        <InputRange maxValue={20} minValue={0} defaultValue={defaultValue} value={value} onChange={onChange} onChangeComplete={onChangeComplete}/>
+      );
+      slider.dispatchEvent(mouseUpEvent);
+
+      expect(onChangeComplete).toHaveBeenCalledWith(inputRange, value);
+    });
+
     it('should not call onChangeComplete if value has not changed since the start of interaction', () => {
       slider.dispatchEvent(mouseDownEvent);
       inputRange = rerenderComponent(


### PR DESCRIPTION
When using `defaultValue` (and having `value` to equal `undefined` or `null` for initial render),`onChangeComplete` is not triggered.

Reason is, `_this.startValue` is not set properly on `handleInteractionStart` method.

This PR fixes it, added a test that will fail when the change is reverted as well.

Thanks 👍 