### PR TITLE
iOS render fix

### DIFF
--- a/scss/_InputRangeLabel.scss
+++ b/scss/_InputRangeLabel.scss
@@ -22,4 +22,6 @@
 .InputRange-label--value {
   position: absolute;
   top: -1.8rem;
+  // fix iOS font render glitch
+  transform: rotateX(0deg);
 }


### PR DESCRIPTION
There's a problem with text rendering on iOS when you moving the values. I attached the image
![ios_render_problem](https://cloud.githubusercontent.com/assets/577042/18839046/e1ce505c-8409-11e6-80fa-111d3558e2b7.png)

Fix is really easy.
