### PR TITLE
Add formatLabel call to value now

### DIFF
--- a/src/InputRange/Slider.js
+++ b/src/InputRange/Slider.js
@@ -164,7 +164,7 @@ export default class Slider extends React.Component {
           aria-controls={ this.props.ariaControls }
           aria-valuemax={ this.props.maxValue }
           aria-valuemin={ this.props.minValue }
-          aria-valuenow={ this.props.value }
+          aria-valuenow={ this.props.formatLabel ? this.props.formatLabel( this.props.value ) : this.props.value }
           className={ classNames.slider }
           draggable="false"
           href="#"


### PR DESCRIPTION
`aria-valuenow` should have format via `formatLabel` because floating point in IEEE 754 works "unpredictable", but correct :)

For example in range with step 0.1 `aria-valuenow` will not make sense, because:
0.2 + 0.1 equals 0.30000000000000004 (and this is correct). In range from 0 to 5 we have 21 such case:
`Array(50).fill(0.1).map((v, i) => v*i + v).filter(v => v.toString().length > 3)`
