### PR TITLE
Upgrade karma-phantomjs-launcher 

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-babel-preprocessor": "^5.2.1",
     "karma-browserify": "^4.3.0",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "lodash": "^3.10.0",
     "phantomjs": "^1.9.17",
     "react": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^1.0.2",
     "lodash": "^3.10.0",
-    "phantomjs": "^1.9.17",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "run-sequence": "^1.1.4",


### PR DESCRIPTION
Upgrade karma-phantomjs-launcher to 1.0.2  to resolve compatibility problems with MacOS Sierra.   This new version pulls in the dependency phantomjs-prebuilt ^2.1.7.