### PR TITLE
Adding ability to show label on hovering the track

### DIFF
--- a/example/js/example-app.jsx
+++ b/example/js/example-app.jsx
@@ -22,6 +22,7 @@ export default class ExampleApp extends React.Component {
     return (
       <form className="form">
         <InputRange
+          showHoverLabel
           maxValue={20}
           minValue={0}
           value={this.state.value}

--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -70,6 +70,8 @@ export default class Slider extends React.Component {
   componentWillUnmount() {
     this.removeDocumentMouseMoveListener();
     this.removeDocumentMouseUpListener();
+    this.removeDocumentMouseOverListener();
+    this.removeDocumentMouseOutListener();
     this.removeDocumentTouchEndListener();
     this.removeDocumentTouchMoveListener();
   }

--- a/src/js/input-range/track.jsx
+++ b/src/js/input-range/track.jsx
@@ -11,6 +11,9 @@ export default class Track extends React.Component {
    * @property {Function} children
    * @property {Function} classNames
    * @property {Function} onTrackMouseDown
+   * @property {Function} onTrackMouseOver
+   * @property {Function} onTrackMouseOut
+   * @property {Function} onTrackMouseMove
    * @property {Function} percentages
    */
   static get propTypes() {
@@ -18,6 +21,9 @@ export default class Track extends React.Component {
       children: React.PropTypes.node.isRequired,
       classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
       onTrackMouseDown: React.PropTypes.func.isRequired,
+      onTrackMouseOver: React.PropTypes.func.isRequired,
+      onTrackMouseOut: React.PropTypes.func.isRequired,
+      onTrackMouseMove: React.PropTypes.func.isRequired,
       percentages: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
     };
   }
@@ -26,6 +32,9 @@ export default class Track extends React.Component {
    * @param {Object} props
    * @param {InputRangeClassNames} props.classNames
    * @param {Function} props.onTrackMouseDown
+   * @param {Function} props.onTrackMouseOver
+   * @param {Function} props.onTrackMouseOut
+   * @param {Function} props.onTrackMouseMove
    * @param {number} props.percentages
    */
   constructor(props) {
@@ -84,6 +93,58 @@ export default class Track extends React.Component {
     this.handleMouseDown(event);
   }
 
+
+  /**
+   * @private
+   * @param {SyntheticEvent} event
+   * @return {void}
+   */
+  @autobind
+  handleMouseMove(event) {
+    const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+    const trackClientRect = this.getClientRect();
+    const position = {
+      x: clientX - trackClientRect.left,
+      y: 0,
+    };
+
+    this.props.onTrackMouseMove(event, position);
+  }
+
+  /**
+   * @private
+   * @param {SyntheticEvent} event
+   * @return {void}
+   */
+  @autobind
+  handleMouseOver(event) {
+    const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+    const trackClientRect = this.getClientRect();
+    const position = {
+      x: clientX - trackClientRect.left,
+      y: 0,
+    };
+
+    this.props.onTrackMouseOver(event, position);
+  }
+
+  /**
+   * @private
+   * @param {SyntheticEvent} event
+   * @return {void}
+   */
+  @autobind
+  handleMouseOut(event) {
+    const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+    const trackClientRect = this.getClientRect();
+    const position = {
+      x: clientX - trackClientRect.left,
+      y: 0,
+    };
+
+    this.props.onTrackMouseOut(event, position);
+  }
+
   /**
    * @override
    * @return {JSX.Element}
@@ -96,6 +157,9 @@ export default class Track extends React.Component {
         className={this.props.classNames.track}
         onMouseDown={this.handleMouseDown}
         onTouchStart={this.handleTouchStart}
+        onMouseOver={this.handleMouseOver}
+        onMouseOut={this.handleMouseOut}
+        onMouseMove={this.handleMouseMove}
         ref={(node) => { this.node = node; }}>
         <div
           style={activeTrackStyle}


### PR DESCRIPTION
Hi @davidchin! Back again!

This is another feature that I found myself wanting - an ability to hover on the track and see the value at that position, if one was to click. I am using this library as a slider for a media player, and it is quite an expected behavior in a media player to be able to view the position at certain point to move accurately.

For the PR, I've followed the conventions that you already have in the library. Most of the functionality is there but the only thing I am struggling with is setting the css for the label appropriately based on the event. I imagine this is something you are more adept than I am, so any help would be much appreciated.

If this looks good, and works, then I'll be happy to add docs, tests, et al.

Thank you!