### PR TITLE
Use class properties instead of experimental decorators

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "plugins": [
     "add-module-exports",
     "transform-object-rest-spread",
-    "transform-decorators-legacy",
+    "transform-class-properties",
     "transform-react-jsx"
   ],
   "presets": ["es2015", "es2016", "react"]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-istanbul": "^3.1.2",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
@@ -89,7 +89,5 @@
     "pretest": "npm run lint",
     "test": "karma start --single-run"
   },
-  "dependencies": {
-    "autobind-decorator": "^1.3.4"
-  }
+  "dependencies": {}
 }

--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import autobind from 'autobind-decorator';
 import * as valueTransformer from './value-transformer';
 import DEFAULT_CLASS_NAMES from './default-class-names';
 import Label from './label';
@@ -20,38 +19,34 @@ export default class InputRange extends React.Component {
    * @override
    * @return {Object}
    */
-  static get propTypes() {
-    return {
-      ariaLabelledby: React.PropTypes.string,
-      ariaControls: React.PropTypes.string,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string),
-      disabled: React.PropTypes.bool,
-      formatLabel: React.PropTypes.func,
-      maxValue: rangePropType,
-      minValue: rangePropType,
-      name: React.PropTypes.string,
-      onChangeStart: React.PropTypes.func,
-      onChange: React.PropTypes.func.isRequired,
-      onChangeComplete: React.PropTypes.func,
-      step: React.PropTypes.number,
-      value: valuePropType,
-    };
-  }
+  static propTypes = {
+    ariaLabelledby: React.PropTypes.string,
+    ariaControls: React.PropTypes.string,
+    classNames: React.PropTypes.objectOf(React.PropTypes.string),
+    disabled: React.PropTypes.bool,
+    formatLabel: React.PropTypes.func,
+    maxValue: rangePropType,
+    minValue: rangePropType,
+    name: React.PropTypes.string,
+    onChangeStart: React.PropTypes.func,
+    onChange: React.PropTypes.func.isRequired,
+    onChangeComplete: React.PropTypes.func,
+    step: React.PropTypes.number,
+    value: valuePropType,
+  };
 
   /**
    * @ignore
    * @override
    * @return {Object}
    */
-  static get defaultProps() {
-    return {
-      classNames: DEFAULT_CLASS_NAMES,
-      disabled: false,
-      maxValue: 10,
-      minValue: 0,
-      step: 1,
-    };
-  }
+  static defaultProps = {
+    classNames: DEFAULT_CLASS_NAMES,
+    disabled: false,
+    maxValue: 10,
+    minValue: 0,
+    step: 1,
+  };
 
   /**
    * @param {Object} props
@@ -169,7 +164,7 @@ export default class InputRange extends React.Component {
     const currentValues = valueTransformer.getValueFromProps(this.props, this.isMultiValue());
 
     return length(values.min, currentValues.min) >= this.props.step ||
-           length(values.max, currentValues.max) >= this.props.step;
+      length(values.max, currentValues.max) >= this.props.step;
   }
 
   /**
@@ -190,8 +185,8 @@ export default class InputRange extends React.Component {
   isWithinRange(values) {
     if (this.isMultiValue()) {
       return values.min >= this.props.minValue &&
-             values.max <= this.props.maxValue &&
-             values.min < values.max;
+        values.max <= this.props.maxValue &&
+        values.min < values.max;
     }
 
     return values.max >= this.props.minValue && values.max <= this.props.maxValue;
@@ -345,8 +340,7 @@ export default class InputRange extends React.Component {
    * @param {string} key
    * @return {void}
    */
-  @autobind
-  handleSliderDrag(event, key) {
+  handleSliderDrag = (event, key) => {
     if (this.props.disabled) {
       return;
     }
@@ -354,7 +348,7 @@ export default class InputRange extends React.Component {
     const position = valueTransformer.getPositionFromEvent(event, this.getTrackClientRect());
 
     requestAnimationFrame(() => this.updatePosition(key, position));
-  }
+  };
 
   /**
    * Handle any "keydown" event received by the slider
@@ -363,8 +357,7 @@ export default class InputRange extends React.Component {
    * @param {string} key
    * @return {void}
    */
-  @autobind
-  handleSliderKeyDown(event, key) {
+  handleSliderKeyDown = (event, key) => {
     if (this.props.disabled) {
       return;
     }
@@ -385,7 +378,7 @@ export default class InputRange extends React.Component {
     default:
       break;
     }
-  }
+  };
 
   /**
    * Handle any "mousedown" event received by the track
@@ -394,8 +387,7 @@ export default class InputRange extends React.Component {
    * @param {Point} position
    * @return {void}
    */
-  @autobind
-  handleTrackMouseDown(event, position) {
+  handleTrackMouseDown = (event, position) => {
     if (this.props.disabled) {
       return;
     }
@@ -403,15 +395,14 @@ export default class InputRange extends React.Component {
     event.preventDefault();
 
     this.updatePosition(this.getKeyByPosition(position), position);
-  }
+  };
 
   /**
    * Handle the start of any mouse/touch event
    * @private
    * @return {void}
    */
-  @autobind
-  handleInteractionStart() {
+  handleInteractionStart = () => {
     if (this.props.onChangeStart) {
       this.props.onChangeStart(this.props.value);
     }
@@ -419,15 +410,14 @@ export default class InputRange extends React.Component {
     if (this.props.onChangeComplete && !isDefined(this.startValue)) {
       this.startValue = this.props.value;
     }
-  }
+  };
 
   /**
    * Handle the end of any mouse/touch event
    * @private
    * @return {void}
    */
-  @autobind
-  handleInteractionEnd() {
+  handleInteractionEnd = () => {
     if (!this.props.onChangeComplete || !isDefined(this.startValue)) {
       return;
     }
@@ -437,7 +427,7 @@ export default class InputRange extends React.Component {
     }
 
     this.startValue = null;
-  }
+  };
 
   /**
    * Handle any "keydown" event received by the component
@@ -445,10 +435,9 @@ export default class InputRange extends React.Component {
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleKeyDown(event) {
+  handleKeyDown = (event) => {
     this.handleInteractionStart(event);
-  }
+  };
 
   /**
    * Handle any "keyup" event received by the component
@@ -456,10 +445,9 @@ export default class InputRange extends React.Component {
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleKeyUp(event) {
+  handleKeyUp = (event) => {
     this.handleInteractionEnd(event);
-  }
+  };
 
   /**
    * Handle any "mousedown" event received by the component
@@ -467,22 +455,20 @@ export default class InputRange extends React.Component {
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleMouseDown(event) {
+  handleMouseDown = (event) => {
     this.handleInteractionStart(event);
     this.addDocumentMouseUpListener();
-  }
+  };
 
   /**
    * Handle any "mouseup" event received by the component
    * @private
    * @param {SyntheticEvent} event
    */
-  @autobind
-  handleMouseUp(event) {
+  handleMouseUp = (event) => {
     this.handleInteractionEnd(event);
     this.removeDocumentMouseUpListener();
-  }
+  };
 
   /**
    * Handle any "touchstart" event received by the component
@@ -490,22 +476,20 @@ export default class InputRange extends React.Component {
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleTouchStart(event) {
+  handleTouchStart = (event) => {
     this.handleInteractionStart(event);
     this.addDocumentTouchEndListener();
-  }
+  };
 
   /**
    * Handle any "touchend" event received by the component
    * @private
    * @param {SyntheticEvent} event
    */
-  @autobind
-  handleTouchEnd(event) {
+  handleTouchEnd = (event) => {
     this.handleInteractionEnd(event);
     this.removeDocumentTouchEndListener();
-  }
+  };
 
   /**
    * Return JSX of sliders

--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import autobind from 'autobind-decorator';
 import Label from './label';
 
 /**
@@ -22,21 +21,19 @@ export default class Slider extends React.Component {
    * @property {Function} type
    * @property {Function} value
    */
-  static get propTypes() {
-    return {
-      ariaLabelledby: React.PropTypes.string,
-      ariaControls: React.PropTypes.string,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-      formatLabel: React.PropTypes.func,
-      maxValue: React.PropTypes.number,
-      minValue: React.PropTypes.number,
-      onSliderDrag: React.PropTypes.func.isRequired,
-      onSliderKeyDown: React.PropTypes.func.isRequired,
-      percentage: React.PropTypes.number.isRequired,
-      type: React.PropTypes.string.isRequired,
-      value: React.PropTypes.number.isRequired,
-    };
-  }
+  static propTypes = {
+    ariaLabelledby: React.PropTypes.string,
+    ariaControls: React.PropTypes.string,
+    classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
+    formatLabel: React.PropTypes.func,
+    maxValue: React.PropTypes.number,
+    minValue: React.PropTypes.number,
+    onSliderDrag: React.PropTypes.func.isRequired,
+    onSliderKeyDown: React.PropTypes.func.isRequired,
+    percentage: React.PropTypes.number.isRequired,
+    type: React.PropTypes.string.isRequired,
+    value: React.PropTypes.number.isRequired,
+  };
 
   /**
    * @param {Object} props
@@ -164,71 +161,64 @@ export default class Slider extends React.Component {
    * @private
    * @return {void}
    */
-  @autobind
-  handleMouseDown() {
+  handleMouseDown = () => {
     this.addDocumentMouseMoveListener();
     this.addDocumentMouseUpListener();
-  }
+  };
 
   /**
    * @private
    * @return {void}
    */
-  @autobind
-  handleMouseUp() {
+  handleMouseUp = () => {
     this.removeDocumentMouseMoveListener();
     this.removeDocumentMouseUpListener();
-  }
+  };
 
   /**
    * @private
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleMouseMove(event) {
+  handleMouseMove = (event) => {
     this.props.onSliderDrag(event, this.props.type);
-  }
+  };
 
   /**
    * @private
    * @return {void}
    */
-  @autobind
-  handleTouchStart() {
+  handleTouchStart = () => {
     this.addDocumentTouchEndListener();
     this.addDocumentTouchMoveListener();
-  }
+  };
 
   /**
    * @private
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleTouchMove(event) {
+  handleTouchMove = (event) => {
     this.props.onSliderDrag(event, this.props.type);
-  }
+  };
 
   /**
    * @private
    * @return {void}
    */
-  @autobind
-  handleTouchEnd() {
+  handleTouchEnd = () => {
     this.removeDocumentTouchMoveListener();
     this.removeDocumentTouchEndListener();
-  }
+  };
 
   /**
    * @private
    * @param {SyntheticEvent} event
    * @return {void}
    */
-  @autobind
-  handleKeyDown(event) {
+  handleKeyDown = (event) => {
     this.props.onSliderKeyDown(event, this.props.type);
-  }
+  };
 
   /**
    * @override

--- a/src/js/input-range/track.jsx
+++ b/src/js/input-range/track.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import autobind from 'autobind-decorator';
 
 /**
  * @ignore
@@ -13,14 +12,12 @@ export default class Track extends React.Component {
    * @property {Function} onTrackMouseDown
    * @property {Function} percentages
    */
-  static get propTypes() {
-    return {
-      children: React.PropTypes.node.isRequired,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-      onTrackMouseDown: React.PropTypes.func.isRequired,
-      percentages: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
-    };
-  }
+  static propTypes = {
+    children: React.PropTypes.node.isRequired,
+    classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
+    onTrackMouseDown: React.PropTypes.func.isRequired,
+    percentages: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
+  };
 
   /**
    * @param {Object} props
@@ -61,8 +58,7 @@ export default class Track extends React.Component {
    * @private
    * @param {SyntheticEvent} event - User event
    */
-  @autobind
-  handleMouseDown(event) {
+  handleMouseDown = (event) => {
     const clientX = event.touches ? event.touches[0].clientX : event.clientX;
     const trackClientRect = this.getClientRect();
     const position = {
@@ -71,18 +67,17 @@ export default class Track extends React.Component {
     };
 
     this.props.onTrackMouseDown(event, position);
-  }
+  };
 
   /**
    * @private
    * @param {SyntheticEvent} event - User event
    */
-  @autobind
-  handleTouchStart(event) {
+  handleTouchStart = (event) => {
     event.preventDefault();
 
     this.handleMouseDown(event);
-  }
+  };
 
   /**
    * @override


### PR DESCRIPTION
This is because the decorators transform is not currently supported(http://babeljs.io/docs/plugins/transform-decorators/), and it decreases the bundle size :)

