### PR TITLE
Code formatting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,7 @@
   "plugins": [
     "add-module-exports",
     "transform-object-rest-spread",
-    "transform-decorators-legacy",
-    "transform-react-jsx"
+    "transform-decorators-legacy"
   ],
   "presets": ["es2015", "es2016", "react"]
 }

--- a/example/js/example-app.jsx
+++ b/example/js/example-app.jsx
@@ -1,22 +1,18 @@
-/* eslint-disable class-methods-use-this, no-console */
-
-import React from 'react';
+/* eslint-disable no-console */
+import React, { Component } from 'react';
 import InputRange from '../../src/js';
 
-export default class ExampleApp extends React.Component {
-  constructor(props) {
-    super(props);
+export default class ExampleApp extends Component {
 
-    this.state = {
-      value: 5,
-      value2: 10,
-      value3: 10,
-      value4: {
-        min: 5,
-        max: 10,
-      },
-    };
-  }
+  state = {
+    value: 5,
+    value2: 10,
+    value3: 10,
+    value4: {
+      min: 5,
+      max: 10,
+    },
+  };
 
   render() {
     return (

--- a/example/js/index.jsx
+++ b/example/js/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import ExampleApp from './example-app';
 import '../../src/scss/index.scss';
 import '../scss/index.scss';
 
-ReactDOM.render(
+render(
   <ExampleApp />,
   document.getElementById('app'),
 );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,55 +1,53 @@
 const path = require('path');
 
-function configureKarma(config) {
-  config.set({
-    basePath: __dirname,
-    browsers: ['PhantomJS'],
-    coverageReporter: {
-        reporters: [
-            { type: 'html' },
-            { type: 'text' },
-        ],
+const configureKarma = config => config.set({
+  basePath: __dirname,
+  browsers: ['PhantomJS'],
+  coverageReporter: {
+    reporters: [
+      { type: 'html' },
+      { type: 'text' },
+    ],
+  },
+  frameworks: ['jasmine'],
+  files: ['test/index.js'],
+  preprocessors: {
+    'src/index.js': ['coverage'],
+    'test/index.js': ['webpack', 'sourcemap'],
+  },
+  reporters: ['mocha', 'coverage'],
+  webpack: {
+    devtool: 'inline-source-map',
+    externals: {
+      'cheerio': 'window',
+      'react/addons': true,
+      'react/lib/ExecutionEnvironment': true,
+      'react/lib/ReactContext': true,
     },
-    frameworks: ['jasmine'],
-    files: ['test/index.js'],
-    preprocessors: {
-      'src/index.js': ['coverage'],
-      'test/index.js': ['webpack', 'sourcemap'],
-    },
-    reporters: ['mocha', 'coverage'],
-    webpack: {
-      devtool: 'inline-source-map',
-      externals: {
-        'cheerio': 'window',
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true,
-      },
-      module: {
-        loaders: [
-          {
-            include: [
-              path.resolve(__dirname, 'src'),
-              path.resolve(__dirname, 'test'),
-            ],
-            loader: 'babel',
-            query: {
-              plugins: ['istanbul'],
-            },
-            test: /\.jsx?$/,
+    module: {
+      loaders: [
+        {
+          include: [
+            path.resolve(__dirname, 'src'),
+            path.resolve(__dirname, 'test'),
+          ],
+          loader: 'babel',
+          query: {
+            plugins: ['istanbul'],
           },
-          {
-            include: path.resolve(__dirname, 'src'),
-            loaders: ['style', 'css', 'postcss', 'sass'],
-            test: /\.scss$/,
-          },
-        ],
-      },
-      resolve: {
-        extensions: ['', '.js', '.jsx'],
-      },
+          test: /\.jsx?$/,
+        },
+        {
+          include: path.resolve(__dirname, 'src'),
+          loaders: ['style', 'css', 'postcss', 'sass'],
+          test: /\.scss$/,
+        },
+      ],
     },
-  });
-}
+    resolve: {
+      extensions: ['', '.js', '.jsx'],
+    },
+  },
+});
 
 module.exports = configureKarma;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-plugin-transform-react-jsx": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.22.0",

--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import autobind from 'autobind-decorator';
 import * as valueTransformer from './value-transformer';
 import DEFAULT_CLASS_NAMES from './default-class-names';
@@ -14,7 +14,7 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from './key-codes';
  * A React component that allows users to input numeric values within a range
  * by dragging its sliders.
  */
-export default class InputRange extends React.Component {
+export default class InputRange extends Component {
   /**
    * @ignore
    * @override
@@ -22,18 +22,18 @@ export default class InputRange extends React.Component {
    */
   static get propTypes() {
     return {
-      ariaLabelledby: React.PropTypes.string,
-      ariaControls: React.PropTypes.string,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string),
-      disabled: React.PropTypes.bool,
-      formatLabel: React.PropTypes.func,
+      ariaLabelledby: PropTypes.string,
+      ariaControls: PropTypes.string,
+      classNames: PropTypes.objectOf(PropTypes.string),
+      disabled: PropTypes.bool,
+      formatLabel: PropTypes.func,
       maxValue: rangePropType,
       minValue: rangePropType,
-      name: React.PropTypes.string,
-      onChangeStart: React.PropTypes.func,
-      onChange: React.PropTypes.func.isRequired,
-      onChangeComplete: React.PropTypes.func,
-      step: React.PropTypes.number,
+      name: PropTypes.string,
+      onChangeStart: PropTypes.func,
+      onChange: PropTypes.func.isRequired,
+      onChangeComplete: PropTypes.func,
+      step: PropTypes.number,
       value: valuePropType,
     };
   }
@@ -169,7 +169,7 @@ export default class InputRange extends React.Component {
     const currentValues = valueTransformer.getValueFromProps(this.props, this.isMultiValue());
 
     return length(values.min, currentValues.min) >= this.props.step ||
-           length(values.max, currentValues.max) >= this.props.step;
+      length(values.max, currentValues.max) >= this.props.step;
   }
 
   /**
@@ -190,8 +190,8 @@ export default class InputRange extends React.Component {
   isWithinRange(values) {
     if (this.isMultiValue()) {
       return values.min >= this.props.minValue &&
-             values.max <= this.props.maxValue &&
-             values.min < values.max;
+        values.max <= this.props.maxValue &&
+        values.min < values.max;
     }
 
     return values.max >= this.props.minValue && values.max <= this.props.maxValue;

--- a/src/js/input-range/label.jsx
+++ b/src/js/input-range/label.jsx
@@ -1,23 +1,19 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 /**
  * @ignore
- * @param {Object} props
- * @param {InputRangeClassNames} props.classNames
- * @param {Function} props.formatLabel
- * @param {string} props.type
+ * @param {InputRangeClassNames} classNames
+ * @param {Function=} formatLabel
+ * @param {Node} children
+ * @param {string} type
  */
-export default function Label(props) {
-  const labelValue = props.formatLabel ? props.formatLabel(props.children, props.type) : props.children;
-
-  return (
-    <span className={props.classNames[`${props.type}Label`]}>
-      <span className={props.classNames.labelContainer}>
-        {labelValue}
-      </span>
+const Label = ({ formatLabel, children, type, classNames }) => (
+  <span className={classNames[`${type}Label`]}>
+    <span className={classNames.labelContainer}>
+      {formatLabel ? formatLabel(children, type) : children}
     </span>
-  );
-}
+  </span>
+);
 
 /**
  * @type {Object}
@@ -27,8 +23,10 @@ export default function Label(props) {
  * @property {Function} type
  */
 Label.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-  formatLabel: React.PropTypes.func,
-  type: React.PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  classNames: PropTypes.objectOf(PropTypes.string).isRequired,
+  formatLabel: PropTypes.func,
+  type: PropTypes.string.isRequired,
 };
+
+export default Label;

--- a/src/js/input-range/range-prop-type.js
+++ b/src/js/input-range/range-prop-type.js
@@ -5,7 +5,7 @@ import { isNumber } from '../utils';
  * @param {Object} props - React component props
  * @return {?Error} Return Error if validation fails
  */
-export default function rangePropType(props) {
+const rangePropType = (props) => {
   const { maxValue, minValue } = props;
 
   if (!isNumber(minValue) || !isNumber(maxValue)) {
@@ -15,4 +15,6 @@ export default function rangePropType(props) {
   if (minValue >= maxValue) {
     return new Error('"minValue" must be smaller than "maxValue"');
   }
-}
+};
+
+export default rangePropType;

--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import autobind from 'autobind-decorator';
 import Label from './label';
 
 /**
  * @ignore
  */
-export default class Slider extends React.Component {
+export default class Slider extends Component {
   /**
    * Accepted propTypes of Slider
    * @override
@@ -24,17 +24,17 @@ export default class Slider extends React.Component {
    */
   static get propTypes() {
     return {
-      ariaLabelledby: React.PropTypes.string,
-      ariaControls: React.PropTypes.string,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-      formatLabel: React.PropTypes.func,
-      maxValue: React.PropTypes.number,
-      minValue: React.PropTypes.number,
-      onSliderDrag: React.PropTypes.func.isRequired,
-      onSliderKeyDown: React.PropTypes.func.isRequired,
-      percentage: React.PropTypes.number.isRequired,
-      type: React.PropTypes.string.isRequired,
-      value: React.PropTypes.number.isRequired,
+      ariaLabelledby: PropTypes.string,
+      ariaControls: PropTypes.string,
+      classNames: PropTypes.objectOf(PropTypes.string).isRequired,
+      formatLabel: PropTypes.func,
+      maxValue: PropTypes.number,
+      minValue: PropTypes.number,
+      onSliderDrag: PropTypes.func.isRequired,
+      onSliderKeyDown: PropTypes.func.isRequired,
+      percentage: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
     };
   }
 

--- a/src/js/input-range/track.jsx
+++ b/src/js/input-range/track.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import autobind from 'autobind-decorator';
 
 /**
  * @ignore
  */
-export default class Track extends React.Component {
+export default class Track extends Component {
   /**
    * @override
    * @return {Object}
@@ -15,10 +15,10 @@ export default class Track extends React.Component {
    */
   static get propTypes() {
     return {
-      children: React.PropTypes.node.isRequired,
-      classNames: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-      onTrackMouseDown: React.PropTypes.func.isRequired,
-      percentages: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
+      children: PropTypes.node.isRequired,
+      classNames: PropTypes.objectOf(PropTypes.string).isRequired,
+      onTrackMouseDown: PropTypes.func.isRequired,
+      percentages: PropTypes.objectOf(PropTypes.number).isRequired,
     };
   }
 

--- a/src/js/input-range/value-prop-type.js
+++ b/src/js/input-range/value-prop-type.js
@@ -3,9 +3,10 @@ import { isNumber, isObject } from '../utils';
 /**
  * @ignore
  * @param {Object} props
+ * @param {String} propName
  * @return {?Error} Return Error if validation fails
  */
-export default function valuePropType(props, propName) {
+const valuePropType = (props, propName) => {
   const { maxValue, minValue } = props;
   const value = props[propName];
 
@@ -20,4 +21,6 @@ export default function valuePropType(props, propName) {
   if (isObject(value) && (value.min < minValue || value.min > maxValue || value.max < minValue || value.max > maxValue)) {
     return new Error(`"${propName}" must be in between "minValue" and "maxValue"`);
   }
-}
+};
+
+export default valuePropType

--- a/src/js/input-range/value-prop-type.js
+++ b/src/js/input-range/value-prop-type.js
@@ -23,4 +23,4 @@ const valuePropType = (props, propName) => {
   }
 };
 
-export default valuePropType
+export default valuePropType;

--- a/src/js/input-range/value-transformer.js
+++ b/src/js/input-range/value-transformer.js
@@ -7,12 +7,12 @@ import { clamp } from '../utils';
  * @param {ClientRect} clientRect
  * @return {number} Percentage value
  */
-export function getPercentageFromPosition(position, clientRect) {
+export const getPercentageFromPosition = (position, clientRect) => {
   const length = clientRect.width;
   const sizePerc = position.x / length;
 
   return sizePerc || 0;
-}
+};
 
 /**
  * Convert a point into a model value
@@ -23,12 +23,12 @@ export function getPercentageFromPosition(position, clientRect) {
  * @param {ClientRect} clientRect
  * @return {number}
  */
-export function getValueFromPosition(position, minValue, maxValue, clientRect) {
+export const getValueFromPosition = (position, minValue, maxValue, clientRect) => {
   const sizePerc = getPercentageFromPosition(position, clientRect);
   const valueDiff = maxValue - minValue;
 
   return minValue + (valueDiff * sizePerc);
-}
+};
 
 /**
  * Convert props into a range value
@@ -37,7 +37,7 @@ export function getValueFromPosition(position, minValue, maxValue, clientRect) {
  * @param {boolean} isMultiValue
  * @return {Range}
  */
-export function getValueFromProps(props, isMultiValue) {
+export const getValueFromProps = (props, isMultiValue) => {
   if (isMultiValue) {
     return { ...props.value };
   }
@@ -46,7 +46,7 @@ export function getValueFromProps(props, isMultiValue) {
     min: props.minValue,
     max: props.value,
   };
-}
+};
 
 /**
  * Convert a model value into a percentage value
@@ -56,13 +56,13 @@ export function getValueFromProps(props, isMultiValue) {
  * @param {number} maxValue
  * @return {number}
  */
-export function getPercentageFromValue(value, minValue, maxValue) {
+export const getPercentageFromValue = (value, minValue, maxValue) => {
   const validValue = clamp(value, minValue, maxValue);
   const valueDiff = maxValue - minValue;
   const valuePerc = (validValue - minValue) / valueDiff;
 
   return valuePerc || 0;
-}
+};
 
 /**
  * Convert model values into percentage values
@@ -72,12 +72,10 @@ export function getPercentageFromValue(value, minValue, maxValue) {
  * @param {number} maxValue
  * @return {Range}
  */
-export function getPercentagesFromValues(values, minValue, maxValue) {
-  return {
-    min: getPercentageFromValue(values.min, minValue, maxValue),
-    max: getPercentageFromValue(values.max, minValue, maxValue),
-  };
-}
+export const getPercentagesFromValues = (values, minValue, maxValue) => ({
+  min: getPercentageFromValue(values.min, minValue, maxValue),
+  max: getPercentageFromValue(values.max, minValue, maxValue),
+});
 
 /**
  * Convert a value into a point
@@ -88,7 +86,7 @@ export function getPercentagesFromValues(values, minValue, maxValue) {
  * @param {ClientRect} clientRect
  * @return {Point} Position
  */
-export function getPositionFromValue(value, minValue, maxValue, clientRect) {
+export const getPositionFromValue = (value, minValue, maxValue, clientRect) => {
   const length = clientRect.width;
   const valuePerc = getPercentageFromValue(value, minValue, maxValue);
   const positionValue = valuePerc * length;
@@ -97,7 +95,7 @@ export function getPositionFromValue(value, minValue, maxValue, clientRect) {
     x: positionValue,
     y: 0,
   };
-}
+};
 
 /**
  * Convert a range of values into points
@@ -108,12 +106,10 @@ export function getPositionFromValue(value, minValue, maxValue, clientRect) {
  * @param {ClientRect} clientRect
  * @return {Range}
  */
-export function getPositionsFromValues(values, minValue, maxValue, clientRect) {
-  return {
-    min: getPositionFromValue(values.min, minValue, maxValue, clientRect),
-    max: getPositionFromValue(values.max, minValue, maxValue, clientRect),
-  };
-}
+export const getPositionsFromValues = (values, minValue, maxValue, clientRect) => ({
+  min: getPositionFromValue(values.min, minValue, maxValue, clientRect),
+  max: getPositionFromValue(values.max, minValue, maxValue, clientRect),
+});
 
 /**
  * Convert an event into a point
@@ -122,7 +118,7 @@ export function getPositionsFromValues(values, minValue, maxValue, clientRect) {
  * @param {ClientRect} clientRect
  * @return {Point}
  */
-export function getPositionFromEvent(event, clientRect) {
+export const getPositionFromEvent = (event, clientRect) => {
   const length = clientRect.width;
   const { clientX } = event.touches ? event.touches[0] : event;
 
@@ -130,7 +126,7 @@ export function getPositionFromEvent(event, clientRect) {
     x: clamp(clientX - clientRect.left, 0, length),
     y: 0,
   };
-}
+};
 
 /**
  * Convert a value into a step value
@@ -139,6 +135,4 @@ export function getPositionFromEvent(event, clientRect) {
  * @param {number} valuePerStep
  * @return {number}
  */
-export function getStepValueFromValue(value, valuePerStep) {
-  return Math.round(value / valuePerStep) * valuePerStep;
-}
+export const getStepValueFromValue = (value, valuePerStep) => Math.round(value / valuePerStep) * valuePerStep;

--- a/test/input-range/input-range.spec.jsx
+++ b/test/input-range/input-range.spec.jsx
@@ -1,6 +1,8 @@
+/* eslint-disable no-use-before-define */
+/* global component */
 import React from 'react';
+import { mount } from 'enzyme';
 import InputRange from '../../src/js';
-import { mount, shallow } from 'enzyme';
 
 let container;
 let requestAnimationFrame;
@@ -26,12 +28,11 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const minSlider = component.find(`Slider [onMouseDown]`).at(0);
-    const maxSlider = component.find(`Slider [onMouseDown]`).at(1);
+    const minSlider = component.find('Slider [onMouseDown]').at(0);
+    const maxSlider = component.find('Slider [onMouseDown]').at(1);
 
     minSlider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
@@ -52,11 +53,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const track = component.find(`Track [onMouseDown]`).first();
+    const track = component.find('Track [onMouseDown]').first();
 
     track.simulate('mouseDown', { clientX: 150, clientY: 50 });
     expect(component.props().value).toEqual({ min: 2, max: 7 });
@@ -73,11 +73,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const track = component.find(`Track [onTouchStart]`).first();
+    const track = component.find('Track [onTouchStart]').first();
 
     track.simulate('touchStart', { touches: [{ clientX: 150, clientY: 50 }] });
     expect(component.props().value).toEqual({ min: 2, max: 7 });
@@ -92,11 +91,10 @@ describe('InputRange', () => {
         minValue={0}
         value={{ min: 2, max: 10 }}
         onChange={value => component.setProps({ value })}
-        step={2}
-      />
+        step={2} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 60, clientY: 50 }));
@@ -117,11 +115,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
-    const slider = component.find(`Slider [onKeyDown]`).first();
+    const slider = component.find('Slider [onKeyDown]').first();
 
     slider.simulate('keyDown', { keyCode: 37 });
     slider.simulate('keyUp', { keyCode: 37 });
@@ -138,11 +135,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
-    const slider = component.find(`Slider [onKeyDown]`).first();
+    const slider = component.find('Slider [onKeyDown]').first();
 
     slider.simulate('keyDown', { keyCode: 65 });
     slider.simulate('keyUp', { keyCode: 65 });
@@ -152,13 +148,12 @@ describe('InputRange', () => {
   it('does not respond to mouse event when it is disabled', () => {
     const jsx = (
       <InputRange
-        disabled={true}
+        disabled
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).at(0);
+    const slider = component.find('Slider [onMouseDown]').at(0);
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
@@ -171,13 +166,12 @@ describe('InputRange', () => {
   it('does not respond to keyboard event when it is disabled', () => {
     const jsx = (
       <InputRange
-        disabled={true}
+        disabled
         value={2}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
-    const slider = component.find(`Slider [onKeyDown]`).first();
+    const slider = component.find('Slider [onKeyDown]').first();
 
     slider.simulate('keyDown', { keyCode: 37 });
     slider.simulate('keyUp', { keyCode: 37 });
@@ -190,12 +184,11 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const minSlider = component.find(`Slider [onMouseDown]`).at(0);
-    const maxSlider = component.find(`Slider [onMouseDown]`).at(1);
+    const minSlider = component.find('Slider [onMouseDown]').at(0);
+    const maxSlider = component.find('Slider [onMouseDown]').at(1);
 
     minSlider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: -20, clientY: 50 }));
@@ -216,11 +209,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={2}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: -20, clientY: 50 }));
@@ -241,11 +233,10 @@ describe('InputRange', () => {
         maxValue={20}
         minValue={0}
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 190, clientY: 50 }));
@@ -256,7 +247,9 @@ describe('InputRange', () => {
   });
 
   it('notifies the parent component when dragging starts', () => {
-    const onChange = jasmine.createSpy('onChange').and.callFake(value => component.setProps({ value }));
+    const onChange = jasmine.createSpy('onChange')
+      .and
+      .callFake(value => component.setProps({ value }));
     const onChangeStart = jasmine.createSpy('onChangeStart');
     const jsx = (
       <InputRange
@@ -264,11 +257,10 @@ describe('InputRange', () => {
         minValue={0}
         value={{ min: 2, max: 10 }}
         onChange={value => component.setProps({ value })}
-        onChangeStart={onChangeStart}
-      />
+        onChangeStart={onChangeStart} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
@@ -280,7 +272,9 @@ describe('InputRange', () => {
   });
 
   it('notifies the parent component when dragging stops', () => {
-    const onChange = jasmine.createSpy('onChange').and.callFake(value => component.setProps({ value }));
+    const onChange = jasmine.createSpy('onChange')
+      .and
+      .callFake(value => component.setProps({ value }));
     const onChangeComplete = jasmine.createSpy('onChangeComplete');
     const jsx = (
       <InputRange
@@ -288,11 +282,10 @@ describe('InputRange', () => {
         minValue={0}
         value={{ min: 2, max: 10 }}
         onChange={onChange}
-        onChangeComplete={onChangeComplete}
-      />
+        onChangeComplete={onChangeComplete} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
@@ -305,7 +298,9 @@ describe('InputRange', () => {
   });
 
   it('does not notify the parent component if there is no change', () => {
-    const onChange = jasmine.createSpy('onChange').and.callFake(value => component.setProps({ value }));
+    const onChange = jasmine.createSpy('onChange')
+      .and
+      .callFake(value => component.setProps({ value }));
     const onChangeComplete = jasmine.createSpy('onChangeComplete');
     const jsx = (
       <InputRange
@@ -313,11 +308,10 @@ describe('InputRange', () => {
         minValue={0}
         value={{ min: 2, max: 10 }}
         onChange={onChange}
-        onChangeComplete={onChangeComplete}
-      />
+        onChangeComplete={onChangeComplete} />
     );
     const component = mount(jsx, { attachTo: container });
-    const slider = component.find(`Slider [onMouseDown]`).first();
+    const slider = component.find('Slider [onMouseDown]').first();
 
     slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 51, clientY: 50 }));
@@ -332,8 +326,7 @@ describe('InputRange', () => {
     const jsx = (
       <InputRange
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
     const label = component.find('Slider Label').first();
@@ -345,9 +338,8 @@ describe('InputRange', () => {
     const jsx = (
       <InputRange
         value={{ min: 2, max: 10 }}
-        formatLabel={(value) => `${value}cm`}
-        onChange={value => component.setProps({ value })}
-      />
+        formatLabel={value => `${value}cm`}
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
     const label = component.find('Slider Label').first();
@@ -359,8 +351,7 @@ describe('InputRange', () => {
     const jsx = (
       <InputRange
         value={{ min: 2, max: 10 }}
-        onChange={value => component.setProps({ value })}
-      />
+        onChange={value => component.setProps({ value })} />
     );
     const component = mount(jsx);
     const sliderHandle = component.find('Slider [role="slider"]').first();
@@ -372,8 +363,7 @@ describe('InputRange', () => {
     const jsx = (
       <InputRange
         value={{ min: 2, max: 10 }}
-        onChange={() => {}}
-      />
+        onChange={() => {}} />
     );
     const component = mount(jsx);
 
@@ -384,8 +374,7 @@ describe('InputRange', () => {
     const jsx = (
       <InputRange
         value={2}
-        onChange={() => {}}
-      />
+        onChange={() => {}} />
     );
     const component = mount(jsx);
 
@@ -397,8 +386,7 @@ describe('InputRange', () => {
       <InputRange
         name="price"
         value={{ min: 2, max: 10 }}
-        onChange={() => {}}
-      />
+        onChange={() => {}} />
     );
     const component = mount(jsx);
     const minInput = component.find('[name="priceMin"][type="hidden"]');
@@ -413,8 +401,7 @@ describe('InputRange', () => {
       <InputRange
         name="price"
         value={5}
-        onChange={() => {}}
-      />
+        onChange={() => {}} />
     );
     const component = mount(jsx);
     const hiddenInput = component.find('[name="price"][type="hidden"]');
@@ -428,7 +415,7 @@ describe('InputRange', () => {
       { minValue: 10, maxValue: 2 },
     ];
 
-    sampleProps.forEach(props => {
+    sampleProps.forEach((props) => {
       expect(InputRange.propTypes.minValue(props)).toEqual(jasmine.any(Error));
       expect(InputRange.propTypes.maxValue(props)).toEqual(jasmine.any(Error));
     });
@@ -443,7 +430,7 @@ describe('InputRange', () => {
       { value: null, minValue: 2, maxValue: 10 },
     ];
 
-    sampleProps.forEach(props => {
+    sampleProps.forEach((props) => {
       expect(InputRange.propTypes.value(props, 'value')).toEqual(jasmine.any(Error));
     });
   });


### PR DESCRIPTION
This PR changes the way some code is formatted and removes an unnecessary dependency

Code changes:
  * Instead of importing just `React` and writing `React.Component` and `React.PropTypes`, import `React, { Component, PropTypes }` so you'll have to write less code and make everything look a bit cleaner
  * Convert normal functions to Arrow function because... They look a lot nicer? ¯\_(ツ)_/¯

Dependency change:
  * Remove `babel-plugin-transform-react-jsx` since this plugin is included(?) with `babel-preset-react` and is thus not needed.