### PR TITLE
Implement new step algorithm

### DIFF
--- a/example/js/example-app.jsx
+++ b/example/js/example-app.jsx
@@ -19,6 +19,17 @@ export default class ExampleApp extends React.Component {
         min: 3,
         max: 7,
       },
+
+      // this will be clamped to the upper step (12)
+      value6: 7,
+
+      // this will be clamped to the upper step (11)
+      value7: 11,
+
+      value8: {
+        min: 2,
+        max: 7,
+      },
     };
   }
 
@@ -65,6 +76,30 @@ export default class ExampleApp extends React.Component {
           onChangeComplete={value => console.log(value)}
           value={this.state.value5} />
 
+        <InputRange
+          maxValue={20}
+          minValue={0}
+          step={6}
+          value={this.state.value6}
+          onChange={value => this.setState({ value6: value })}
+          onChangeComplete={value => console.log(value)} />
+
+        <InputRange
+          maxValue={20}
+          minValue={5}
+          step={6}
+          value={this.state.value7}
+          onChange={value => this.setState({ value7: value })}
+          onChangeComplete={value => console.log(value)} />
+
+        <InputRange
+          draggableTrack
+          maxValue={20}
+          minValue={1}
+          step={3}
+          value={this.state.value8}
+          onChange={value => this.setState({ value8: value })}
+          onChangeComplete={value => console.log(value)} />
       </form>
     );
   }

--- a/src/js/input-range/value-transformer.js
+++ b/src/js/input-range/value-transformer.js
@@ -1,4 +1,4 @@
-import { clamp } from '../utils';
+import { clamp, isObject } from '../utils';
 
 /**
  * Convert a point into a percentage value
@@ -34,11 +34,10 @@ export function getValueFromPosition(position, minValue, maxValue, clientRect) {
  * Convert props into a range value
  * @ignore
  * @param {Object} props
- * @param {boolean} isMultiValue
  * @return {Range}
  */
-export function getValueFromProps(props, isMultiValue) {
-  if (isMultiValue) {
+export function getValueFromProps(props) {
+  if (isObject(props.value)) {
     return { ...props.value };
   }
 
@@ -132,13 +131,16 @@ export function getPositionFromEvent(event, clientRect) {
   };
 }
 
-/**
- * Convert a value into a step value
- * @ignore
- * @param {number} value
- * @param {number} valuePerStep
- * @return {number}
- */
-export function getStepValueFromValue(value, valuePerStep) {
-  return Math.round(value / valuePerStep) * valuePerStep;
+export function roundToStep(val, min, max, stepSize) {
+  // round to closest step except when val is max as it could round to the lower step.
+  // (because max is a special step).
+  if (val >= max) {
+    return max;
+  }
+
+  return (Math.round((val - min) / stepSize) * stepSize) + min;
+}
+
+export function ceilToStep(val, min, step) {
+  return (Math.ceil((val - min) / step) * step) + min;
 }


### PR DESCRIPTION
The current step algorithm has a weird behavior when used with `minValue` & `maxValue` values that are not multiples of `step`. (as reported by https://github.com/davidchin/react-input-range/issues/46)

This PR introduces a new step algorithm which:
- rounds the initial value to the next step.
- starts the steps at `minValue`.
- threats `maxValue` as a valid step even if it isn't a multiple of `step`.

eg. with `minValue = 2, maxValue = 14, step = 5`
Using the current algorithm the steps are: `5, 10` (and a broken initial step of `0`)
Using the new algorithm the steps would be: `2, 7, 12, 14`

This should be considered a breaking change.