### PR TITLE
Set z-index of last used slider handle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,9 @@ rules:
     - after-props
   react/require-default-props:
     - 0
+  no-param-reassign:
+    - error
+    - props: false
 env:
   es6: true
   browser: true

--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -89,6 +89,17 @@ export default class Slider extends React.Component {
   }
 
   /**
+  * @private
+  * @return {void}
+  */
+  setZIndex() {
+    this.node.parentElement.childNodes.forEach((child) => {
+      child.style.zIndex = '0';
+    });
+    this.node.style.zIndex = '2';
+  }
+
+  /**
    * Listen to mousemove event
    * @private
    * @return {void}
@@ -168,6 +179,7 @@ export default class Slider extends React.Component {
   handleMouseDown() {
     this.addDocumentMouseMoveListener();
     this.addDocumentMouseUpListener();
+    this.setZIndex(this.node);
   }
 
   /**
@@ -198,6 +210,7 @@ export default class Slider extends React.Component {
   handleTouchStart() {
     this.addDocumentTouchEndListener();
     this.addDocumentTouchMoveListener();
+    this.node.style.zIndex = '2';
   }
 
   /**
@@ -228,6 +241,7 @@ export default class Slider extends React.Component {
   @autobind
   handleKeyDown(event) {
     this.props.onSliderKeyDown(event, this.props.type);
+    this.node.style.zIndex = '2';
   }
 
   /**
@@ -236,7 +250,6 @@ export default class Slider extends React.Component {
    */
   render() {
     const style = this.getStyle();
-
     return (
       <span
         className={this.props.classNames.sliderContainer}

--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -210,7 +210,7 @@ export default class Slider extends React.Component {
   handleTouchStart() {
     this.addDocumentTouchEndListener();
     this.addDocumentTouchMoveListener();
-    this.node.style.zIndex = '2';
+    this.setZIndex(this.node);
   }
 
   /**
@@ -241,7 +241,7 @@ export default class Slider extends React.Component {
   @autobind
   handleKeyDown(event) {
     this.props.onSliderKeyDown(event, this.props.type);
-    this.node.style.zIndex = '2';
+    this.setZIndex(this.node);
   }
 
   /**


### PR DESCRIPTION
I'm using this on a project we're currently building.

If it's something you'd like to integrate into the master branch let e know and I'll do some refactoring to make this feature optional.

Reason behind change -
We've given each handle a 44px square touchzone.
Sometimes the handles' touchzone overlaps on the range slider. We want our users to be able to select the last used handle in that case.

Note -
Also needed to modify eslint rules to allow setting styles when looping through child nodes.