### PR TITLE
Fixing compiler errors

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import { InputRange } from './input-range';
+import InputRange from './input-range/input-range';
 
 /**
  * @ignore


### PR DESCRIPTION
I tried using your project with typescript, and hit a rock:
I imported it like this to get the types:

`import {InputRange} from 'react-input-range';`

But then I couldn't get the component work, because InputRange was undefined.

The same happened when I tried to check your project out, run yarn and yarn dev.

There is something wrong with the imports. With this little fix (?) ist works.