### PR TITLE
remove event listener handleTouchEnd when Slider unmounts

### DIFF
--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -158,7 +158,7 @@ export default class Slider extends React.Component {
    * @return {void}
    */
   removeDocumentTouchEndListener() {
-    this.node.ownerDocument.removeEventListener('touchend', this.handleTouchUp);
+    this.node.ownerDocument.removeEventListener('touchend', this.handleTouchEnd);
   }
 
   /**


### PR DESCRIPTION
The handleTouchEnd event listener is currently not being removed when the slider component is unmounted due to a typo.