### PR TITLE
Add export default

### DIFF
--- a/react-input-range.d.ts
+++ b/react-input-range.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-declare interface Range {
+export declare interface Range {
   max: number;
   min: number;
 }

--- a/react-input-range.d.ts
+++ b/react-input-range.d.ts
@@ -37,3 +37,5 @@ declare interface InputRangeProps {
 declare class InputRange extends React.Component<InputRangeProps, any> {
 
 }
+
+export default InputRange;


### PR DESCRIPTION
When using typescript compiler checks for default export in definition file, too.

If no default export is declared, this import:

```
import InputRange from 'react-input-range';
```

would result in an error:

```
Module '".../node_modules/react-input-range/react-input-range"' has no default export
```
