### PR TITLE
Improve handling of decimal min/max inputs and fractional step values

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -167,6 +167,19 @@ export default class InputRange extends React.Component {
   }
 
   /**
+   * Return numerical precision of the step value
+   * @private
+   * @return {number}
+   */
+  getStepPrecision() {
+    const step = this.props.step;
+    let e = 1;
+    let p = 0;
+    while (Math.round(step * e) / e !== step) { e *= 10; p += 1; }
+    return p;
+  }
+
+  /**
    * Return true if the difference between the new and the current value is
    * greater or equal to the step amount of the component
    * @private
@@ -175,9 +188,9 @@ export default class InputRange extends React.Component {
    */
   hasStepDifference(values) {
     const currentValues = valueTransformer.getValueFromProps(this.props, this.isMultiValue());
-
-    return length(values.min, currentValues.min) >= this.props.step ||
-           length(values.max, currentValues.max) >= this.props.step;
+    const precision = this.getStepPrecision();
+    return length(values.min, currentValues.min, precision) >= this.props.step ||
+           length(values.max, currentValues.max, precision) >= this.props.step;
   }
 
   /**
@@ -246,8 +259,8 @@ export default class InputRange extends React.Component {
     };
 
     const transformedValues = {
-      min: valueTransformer.getStepValueFromValue(values.min, this.props.step),
-      max: valueTransformer.getStepValueFromValue(values.max, this.props.step),
+      min: valueTransformer.getStepValueFromValue(values.min, this.props.step, this.props.minValue, this.props.maxValue),
+      max: valueTransformer.getStepValueFromValue(values.max, this.props.step, this.props.minValue, this.props.maxValue),
     };
 
     this.updateValues(transformedValues);
@@ -384,11 +397,11 @@ export default class InputRange extends React.Component {
 
     const position = valueTransformer.getPositionFromEvent(event, this.getTrackClientRect());
     const value = valueTransformer.getValueFromPosition(position, minValue, maxValue, this.getTrackClientRect());
-    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step);
+    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step, this.props.minValue, this.props.maxValue);
 
     const prevPosition = valueTransformer.getPositionFromEvent(prevEvent, this.getTrackClientRect());
     const prevValue = valueTransformer.getValueFromPosition(prevPosition, minValue, maxValue, this.getTrackClientRect());
-    const prevStepValue = valueTransformer.getStepValueFromValue(prevValue, this.props.step);
+    const prevStepValue = valueTransformer.getStepValueFromValue(prevValue, this.props.step, this.props.minValue, this.props.maxValue);
 
     const offset = prevStepValue - stepValue;
 
@@ -453,8 +466,7 @@ export default class InputRange extends React.Component {
     event.preventDefault();
 
     const value = valueTransformer.getValueFromPosition(position, minValue, maxValue, this.getTrackClientRect());
-    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step);
-
+    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step, this.props.minValue, this.props.maxValue);
     if (!this.props.draggableTrack || stepValue > max || stepValue < min) {
       this.updatePosition(this.getKeyByPosition(position), position);
     }

--- a/src/js/input-range/value-transformer.js
+++ b/src/js/input-range/value-transformer.js
@@ -139,6 +139,6 @@ export function getPositionFromEvent(event, clientRect) {
  * @param {number} valuePerStep
  * @return {number}
  */
-export function getStepValueFromValue(value, valuePerStep) {
-  return Math.round(value / valuePerStep) * valuePerStep;
+export function getStepValueFromValue(value, valuePerStep, minValue, maxValue) {
+  return clamp(Math.round(value / valuePerStep) * valuePerStep, minValue, maxValue);
 }

--- a/src/js/utils/length.js
+++ b/src/js/utils/length.js
@@ -3,8 +3,9 @@
  * @ignore
  * @param {number} numA
  * @param {number} numB
+ * @param {number} precision
  * @return {number}
  */
-export default function length(numA, numB) {
-  return Math.abs(numA - numB);
+export default function length(numA, numB, precision) {
+  return Math.abs(numA - numB).toFixed(precision);
 }

--- a/test/input-range/input-range.spec.jsx
+++ b/test/input-range/input-range.spec.jsx
@@ -111,6 +111,48 @@ describe('InputRange', () => {
     component.detach();
   });
 
+  it('decimal min/max values that round up allow slider movement from end limits', () => {
+    const jsx = (
+      <InputRange
+        maxValue={20.5}
+        minValue={0}
+        value={{ min: 0, max: 20.5 }}
+        onChange={value => component.setProps({ value })}
+        step={1}
+      />
+    );
+    const component = mount(jsx, { attachTo: container });
+    const slider = component.find(`Slider [onMouseDown]`).first();
+
+    slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 100, clientY: 50 }));
+    expect(component.props().value).toEqual({ min: 4, max: 20.5 });
+
+    component.detach();
+  });
+
+  it('fractional steps reach the end of the range', () => {
+    const jsx = (
+      <InputRange
+        maxValue={20}
+        minValue={0}
+        value={2}
+        onChange={value => component.setProps({ value })}
+        step={0.1}
+      />
+    );
+    const component = mount(jsx, { attachTo: container });
+    const slider = component.find(`Slider [onMouseDown]`).first();
+
+    slider.simulate('mouseDown', { clientX: 50, clientY: 50 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 400, clientY: 50 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 400, clientY: 50 }));
+    expect(component.props().value).toEqual(20);
+
+    component.detach();
+  });
+
   it('updates the current value when the user hits one of the arrow keys', () => {
     const jsx = (
       <InputRange


### PR DESCRIPTION
Changes to handle non-integer numbers. Some of the Math.* functions produce Numeric outputs that can vary slightly (due to floating point inaccuracies), such that some of the equality and inequality tests in the library will return a fail value, and valid updates are blocked.

fixes #104 

- Introduction of clamp method into the step calculation function so that slider values are always within a valid range
- test case "decimal min/max values that round up allow slider movement from end limits" added

fixes #23 

- when calculating the new step difference via the length function, round to the precision of the supplied step value. This stops floating point inaccuracies from preventing valid updates
- test case "fractional steps reach the end of the range" added