### PR TITLE
Add a unique identifier to Slider (#1)

### DIFF
--- a/src/js/input-range/slider.jsx
+++ b/src/js/input-range/slider.jsx
@@ -240,7 +240,7 @@ export default class Slider extends React.Component {
 
     return (
       <span
-        className={this.props.classNames.sliderContainer}
+        className={`${this.props.classNames.sliderContainer} ${this.props.type}`}
         ref={(node) => { this.node = node; }}
         style={style}>
         <Label


### PR DESCRIPTION
This came as a need I have to style the 2 sliders label differently. The 2 sliders are identical in structure and classes so it is really hard to access them and style them separately. The change uses the type as an additional class (one slider will have additional class 'max' and one will have additional class 'min' E.G. <span class="input-range__slider-container min" style="position: absolute; left: 25%;">
If you think there is a better way to distinguish them please tell me - I will be happy to apply it. Anything that will let me access the 2 labels separately 
Thanks for your awesome work :)