### PR TITLE
Constrain multi-slider values to within min/max range.

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -262,7 +262,16 @@ export default class InputRange extends React.Component {
       max: valueTransformer.getStepValueFromValue(values.max, this.props.step),
     };
 
-    this.updateValues(transformedValues);
+    const valuesWithinRange = {
+      min: transformedValues.min < this.props.minValue
+        ? this.props.minValue
+        : transformedValues.min,
+      max: transformedValues.max > this.props.maxValue
+        ? this.props.maxValue
+        : transformedValues.max,
+    };
+
+    this.updateValues(valuesWithinRange);
   }
 
   /**

--- a/test/input-range/input-range.spec.jsx
+++ b/test/input-range/input-range.spec.jsx
@@ -235,6 +235,42 @@ describe('InputRange', () => {
     component.detach();
   });
 
+  it('restricts min within valid range when the user clicks on the left edge of the min handle', () => {
+    const jsx = (
+      <InputRange
+        maxValue={20}
+        minValue={0}
+        value={{ min: 0, max: 7 }}
+        onChange={value => component.setProps({ value })}
+      />
+    );
+    const component = mount(jsx, { attachTo: container });
+    const slider = component.find(`Slider [onMouseDown]`).first();
+
+    slider.simulate('mouseDown', { clientX: -20, clientY: 50 });
+    expect(component.props().value).toEqual({ min: 0, max: 7 });
+
+    component.detach();
+  });
+
+  it('restricts max within valid range when the user clicks on the right edge of max handle', () => {
+    const jsx = (
+      <InputRange
+        maxValue={20}
+        minValue={0}
+        value={{ min: 5, max: 20 }}
+        onChange={value => component.setProps({ value })}
+      />
+    );
+    const component = mount(jsx, { attachTo: container });
+    const slider = component.find(`Slider [onMouseDown]`).first();
+
+    slider.simulate('mouseDown', { clientX: 420, clientY: 50 });
+    expect(component.props().value).toEqual({ min: 5, max: 20 });
+
+    component.detach();
+  });
+
   it('prevents the minimum value from exceeding the maximum value', () => {
     const jsx = (
       <InputRange


### PR DESCRIPTION
Addresses the “range out of scope” issue - https://github.com/davidchin/react-input-range/issues/117

The issue was happening on a multi-value slider with a wide range of accepted values, when you click on the "outside" edge of the handle. 

For example, if the range slider goes from 1 to 100, and my min is on 1, I could make the min go to -1 by clicking on the left edge of the handle and letting go.

I added two tests - one for the min, one for the max. 
