### PR TITLE
Fix 'draggableTrack' when 'number' used instead of 'range'

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -406,7 +406,7 @@ export default class InputRange extends React.Component {
 
     const transformedValues = {
       min: min - offset,
-      max: max - offset,
+      max: (typeof max == "undefined") ? stepValue : (max - offset)
     };
 
     this.updateValues(transformedValues);


### PR DESCRIPTION
This fix allows `draggableTrack={true}` to be used, even when `value` is `number`.

Currently it only works when `value` is `Range`.

This resolves issue #124 