### PR TITLE
Fix dragging the slider on iOS

### DIFF
--- a/example/js/example-app.jsx
+++ b/example/js/example-app.jsx
@@ -23,6 +23,7 @@ export default class ExampleApp extends React.Component {
         min: 3,
         max: 7,
       },
+      value7: 4,
     };
   }
 
@@ -77,6 +78,16 @@ export default class ExampleApp extends React.Component {
           onChange={value => this.setState({ value6: value })}
           onChangeComplete={value => console.log(value)}
           value={this.state.value6} />
+
+        <div className="touch-friendly">
+          <InputRange
+            maxValue={20}
+            formatLabel={() => null}
+            minValue={0}
+            value={this.state.value7}
+            onChange={value => this.setState({ value7: value })}
+            onChangeComplete={value => console.log(value)} />
+        </div>
       </form>
     );
   }

--- a/example/scss/index.scss
+++ b/example/scss/index.scss
@@ -10,3 +10,24 @@
 .input-range {
   margin-bottom: 160px;
 }
+
+.touch-friendly {
+  .input-range {
+    &__track {
+      height: 30px;
+
+      &--active {
+        background: rgba(#3f51b5, 0.5)
+      }
+    }
+
+    &__slider {
+      width: 40px;
+      height: 40px;
+
+      &-container {
+        top: 5px;
+      }
+    }
+  }
+}

--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -108,12 +108,17 @@ export default class InputRange extends React.Component {
     this.lastKeyMoved = null;
   }
 
+  componentDidMount() {
+    this.addNodeTouchStartListener();
+  }
+
   /**
    * @ignore
    * @override
    * @return {void}
    */
   componentWillUnmount() {
+    this.removeNodeTouchStartListener();
     this.removeDocumentMouseUpListener();
     this.removeDocumentTouchEndListener();
   }
@@ -321,6 +326,22 @@ export default class InputRange extends React.Component {
   }
 
   /**
+   * Start listening to touchstart events on the node
+   * @private
+   * @return {void}
+   */
+  addNodeTouchStartListener() {
+    // Adding a `onTouchStart` prop to the node doesn't work, as the
+    // event handler will be added as `passive`. The handler needs to
+    // be active, so it is able to call `preventDefault()`. Otherwise
+    // e.g. the page scrolls while dragging slightly vertically.
+    this.node.addEventListener('touchstart', this.handleTouchStart, {
+      passive: false,
+    });
+  }
+
+
+  /**
    * Listen to mouseup event
    * @private
    * @return {void}
@@ -347,6 +368,15 @@ export default class InputRange extends React.Component {
    */
   removeDocumentMouseUpListener() {
     this.node.ownerDocument.removeEventListener('mouseup', this.handleMouseUp);
+  }
+
+  /**
+   * Stop listening to touchstart events on the node
+   * @private
+   * @return {void}
+   */
+  removeNodeTouchStartListener() {
+    this.node.removeEventListener('touchstart', this.handleTouchStart);
   }
 
   /**
@@ -565,6 +595,7 @@ export default class InputRange extends React.Component {
   handleTouchStart(event) {
     this.handleInteractionStart(event);
     this.addDocumentTouchEndListener();
+    event.preventDefault();
   }
 
   /**
@@ -663,8 +694,7 @@ export default class InputRange extends React.Component {
         className={componentClassName}
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}
-        onMouseDown={this.handleMouseDown}
-        onTouchStart={this.handleTouchStart}>
+        onMouseDown={this.handleMouseDown}>
         <Label
           classNames={this.props.classNames}
           formatLabel={this.props.formatLabel}


### PR DESCRIPTION
In Safari on iOS I noticed that dragging the slider doesn't work, if the finger is moved along the track. This doesn't practically happen in your demos, as the track is very tiny, but if you increase the size for better touch support, you'll see this issue. Another issue is, that while dragging the slider, the page will scroll with the finger.


https://user-images.githubusercontent.com/4038316/152819467-06f30a71-61c9-4e57-99a7-bf64c7f80455.mov




A call to `preventDefault()` in the `touchstart` handler fixes this issue. However, React attaches the event handler as `passive` and currently [doesn't offer an API](https://github.com/facebook/react/issues/6436) for opting into active mode. Therefore we need to handle the handler registration ourselves.

Now everything works as expected:


https://user-images.githubusercontent.com/4038316/152819564-d6e69fb2-0ff7-4112-9346-f4369a5a61a1.mov



Would be great if we could get this merged and released in the near future 🙂 