### PR TITLE
Fix min and max values calculation on mouse dragging + keyboard navigation range overflow

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -186,7 +186,7 @@ export default class InputRange extends React.Component {
     const currentValues = valueTransformer.getValueFromProps(this.props, this.isMultiValue());
 
     return length(values.min, currentValues.min) >= this.props.step ||
-           length(values.max, currentValues.max) >= this.props.step;
+      length(values.max, currentValues.max) >= this.props.step;
   }
 
   /**
@@ -207,10 +207,10 @@ export default class InputRange extends React.Component {
   isWithinRange(values) {
     if (this.isMultiValue()) {
       return values.min >= this.props.minValue &&
-             values.max <= this.props.maxValue &&
-             this.props.allowSameValues
-              ? values.min <= values.max
-              : values.min < values.max;
+        values.max <= this.props.maxValue &&
+        this.props.allowSameValues
+        ? values.min <= values.max
+        : values.min < values.max;
     }
 
     return values.max >= this.props.minValue && values.max <= this.props.maxValue;
@@ -258,10 +258,9 @@ export default class InputRange extends React.Component {
     };
 
     const transformedValues = {
-      min: valueTransformer.getStepValueFromValue(values.min, this.props.step),
-      max: valueTransformer.getStepValueFromValue(values.max, this.props.step),
+      min: valueTransformer.getStepValueFromValue(this.props.minValue, values.min, this.props.step),
+      max: valueTransformer.getStepValueFromValue(this.props.minValue, values.max, this.props.step),
     };
-
     this.updateValues(transformedValues);
   }
 
@@ -396,11 +395,11 @@ export default class InputRange extends React.Component {
 
     const position = valueTransformer.getPositionFromEvent(event, this.getTrackClientRect());
     const value = valueTransformer.getValueFromPosition(position, minValue, maxValue, this.getTrackClientRect());
-    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step);
+    const stepValue = valueTransformer.getStepValueFromValue(this.props.minValue, value, this.props.step);
 
     const prevPosition = valueTransformer.getPositionFromEvent(prevEvent, this.getTrackClientRect());
     const prevValue = valueTransformer.getValueFromPosition(prevPosition, minValue, maxValue, this.getTrackClientRect());
-    const prevStepValue = valueTransformer.getStepValueFromValue(prevValue, this.props.step);
+    const prevStepValue = valueTransformer.getStepValueFromValue(this.props.minValue, prevValue, this.props.step);
 
     const offset = prevStepValue - stepValue;
 
@@ -465,7 +464,7 @@ export default class InputRange extends React.Component {
     event.preventDefault();
 
     const value = valueTransformer.getValueFromPosition(position, minValue, maxValue, this.getTrackClientRect());
-    const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step);
+    const stepValue = valueTransformer.getStepValueFromValue(this.props.minValue, value, this.props.step);
 
     if (!this.props.draggableTrack || stepValue > max || stepValue < min) {
       this.updatePosition(this.getKeyByPosition(position), position);

--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -208,9 +208,9 @@ export default class InputRange extends React.Component {
     if (this.isMultiValue()) {
       return values.min >= this.props.minValue &&
         values.max <= this.props.maxValue &&
-        this.props.allowSameValues
-        ? values.min <= values.max
-        : values.min < values.max;
+        (this.props.allowSameValues
+          ? values.min <= values.max
+          : values.min < values.max);
     }
 
     return values.max >= this.props.minValue && values.max <= this.props.maxValue;

--- a/src/js/input-range/value-transformer.js
+++ b/src/js/input-range/value-transformer.js
@@ -135,10 +135,11 @@ export function getPositionFromEvent(event, clientRect) {
 /**
  * Convert a value into a step value
  * @ignore
+ * @param {number} minValue
  * @param {number} value
  * @param {number} valuePerStep
  * @return {number}
  */
-export function getStepValueFromValue(value, valuePerStep) {
-  return Math.round(value / valuePerStep) * valuePerStep;
+export function getStepValueFromValue(minValue, value, valuePerStep) {
+  return minValue + (valuePerStep * Math.round((value - minValue) / valuePerStep));
 }

--- a/test/input-range/value-transformer.spec.js
+++ b/test/input-range/value-transformer.spec.js
@@ -1,0 +1,25 @@
+import { getStepValueFromValue } from '../../src/js/input-range/value-transformer';
+
+describe('getStepValueFromValue', () => {
+  it('should return the correct value with even step', () => {
+    const minValue = 1;
+    const step = 2;
+    expect(getStepValueFromValue(minValue, 3, step)).toBe(3);
+    expect(getStepValueFromValue(minValue, 4, step)).toBe(5);
+    expect(getStepValueFromValue(minValue, 5.5, step)).toBe(5);
+    expect(getStepValueFromValue(minValue, 6.5, step)).toBe(7);
+    expect(getStepValueFromValue(minValue, 7, step)).toBe(7);
+    expect(getStepValueFromValue(minValue, 9, step)).toBe(9);
+  });
+
+  it('should return the correct value with odd step', () => {
+    const minValue = 0;
+    const step = 1;
+    expect(getStepValueFromValue(minValue, 0, step)).toBe(0);
+    expect(getStepValueFromValue(minValue, 1, step)).toBe(1);
+    expect(getStepValueFromValue(minValue, 1.3, step)).toBe(1);
+    expect(getStepValueFromValue(minValue, 1.5, step)).toBe(2);
+    expect(getStepValueFromValue(minValue, 2, step)).toBe(2);
+    expect(getStepValueFromValue(minValue, 3, step)).toBe(3);
+  });
+});


### PR DESCRIPTION
Hi, here is a PR to fix 2 issues : 

- When min value is not a multiple of step value, a bug appeared on mouse dragging : https://codepen.io/mattgic/pen/NEGJgQ/
This has been fixed using minValue in getStepValueFromValue function.

- Missing parenthesis caused a keyboard navigation issue : range could be overflowed on multi value slider. (#131) 
