### PR TITLE
Fix spelling error

### DIFF
--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -1,4 +1,4 @@
-export { default as captialize } from './captialize';
+export { default as capitalize } from './capitalize';
 export { default as clamp } from './clamp';
 export { default as distanceTo } from './distance-to';
 export { default as isDefined } from './is-defined';


### PR DESCRIPTION
A typo in the import was causing compilation errors for me. Could cause hard-to-detect problems with plain js.