### PR TITLE
Very subtle logic error here

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -208,9 +208,9 @@ export default class InputRange extends React.Component {
     if (this.isMultiValue()) {
       return values.min >= this.props.minValue &&
              values.max <= this.props.maxValue &&
-             this.props.allowSameValues
+             (this.props.allowSameValues
               ? values.min <= values.max
-              : values.min < values.max;
+              : values.min < values.max);
     }
 
     return values.max >= this.props.minValue && values.max <= this.props.maxValue;


### PR DESCRIPTION
This won't affect most people in day-to-day usage, but this logic is incorrect. Without the parentheses around the ternary operator, EVERYTHING up to the "?" in the ternary operator will be evaluated as a single logic check. That is, "values.min >= this.props.minValue && values.max <= this.props.maxValue && this.props.allowSameValues" are all evaluated as the logic check of the ternary operator. This isn't the intent, I'm sure. I can cause this method to return true even when it shouldn't. For instance, change minValue to be minValue + 1 and maxValue to be maxValue - 1 and then move the slider to minValue on the track. It shouldn't work, but it does. Similarly, move the slider to maxValue on the track and it'll still work even though it shouldn't. Putting parentheses around the ternary expression fixes this and causes the proper behavior.