### PR TITLE
Update track.jsx

### DIFF
--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -462,7 +462,7 @@ export default class InputRange extends React.Component {
       value: { max, min },
     } = this.props;
 
-    event.preventDefault();
+    if (event.cancelable) event.preventDefault();
 
     const value = valueTransformer.getValueFromPosition(position, minValue, maxValue, this.getTrackClientRect());
     const stepValue = valueTransformer.getStepValueFromValue(value, this.props.step);

--- a/src/js/input-range/input-range.jsx
+++ b/src/js/input-range/input-range.jsx
@@ -137,7 +137,7 @@ export default class InputRange extends React.Component {
    * @return {ClientRect}
    */
   getTrackClientRect() {
-    return this.trackNode.getClientRect();
+    return this.trackNode?.getClientRect();
   }
 
   /**

--- a/src/js/input-range/track.jsx
+++ b/src/js/input-range/track.jsx
@@ -161,7 +161,7 @@ export default class Track extends React.Component {
    */
   @autobind
   handleTouchStart(event) {
-    event.preventDefault();
+    if (event.cancelable) event.preventDefault();
 
     this.handleMouseDown(event);
   }


### PR DESCRIPTION
Handled the exceptions: 
1. [Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example, because scrolling is in progress and cannot be interrupted.

2. TypeError: null is not an object (evaluating 'this.trackNode.getClientRect')